### PR TITLE
Sync Merge: ci/sync_merge_gitlab_to_github

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,95 +1,163 @@
 stages:
-  - build
-  - deploy
-  - comment
+  # - build
+  # - deploy
+  # - comment
+  - sync_merge
 
-build_hugo:
-  stage: build
-  image: "${CI_TEMPLATE_REGISTRY_HOST}/pages/hugo/hugo_extended:0.135.0"
-  tags:
-    - build_docs
-  rules:
-    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  variables:
-    GIT_SUBMODULE_STRATEGY: recursive
-    NAME: "${CI_COMMIT_REF_SLUG}"
-  script:
-    - hugo --gc --minify --environment staging --baseURL "${DOCS_PREVIEW_URL_BASE}/${NAME}"
-    # use branch name like directory name for the URL path going forward
-    - mv -v public "${NAME}"
-    - tar -czf archive.tar.gz "${NAME}"
-  artifacts:
-    paths:
-      - archive.tar.gz
-    expire_in: 1 week
-
-deploy_preview_hugo:
-  stage: deploy
-  image: espressif/scp
+# After testing:
+#- Replace f-hollow with espressif
+#- Replace enhancement with GitLab-Sync-Merge
+#- Figure out which GitHub token to use
+sync_merge_to_github:
+  stage: sync_merge
+  image: debian:latest
   tags:
     - deploy_docs
     - shiny
   rules:
-    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  needs: ["build_hugo"]
-  variables:
-    SSH_KEY: "$DOCS_PREVIEW_PRIVATEKEY" # SSH_KEY used inside espressif/scp
-    SERVER_PATH: "$DOCS_PREVIEW_PATH"
-    SERVER_URL_BASE: "$DOCS_PREVIEW_URL_BASE"
-    USER: "$DOCS_PREVIEW_SERVER_USER"
-    SERVER: "$DOCS_PREVIEW_SERVER"
-    NAME: "${CI_COMMIT_REF_SLUG}"
+    - if: '$CI_MERGE_REQUEST_LABELS =~ /GitHub-Sync-Merge/'
   script:
-    # upload and extract the archive,
-    # delete the old directory with the same name (if doesn't contain . or /)
-    # so as not to accumulate garbage from the previous run
-    - cat archive.tar.gz | ssh ${USER}@${SERVER}
-        "cd ${SERVER_PATH};
-        [[ \"$NAME\" != *.* && \"$NAME\" != */* ]] && [ -d \"$NAME\" ] && rm -rf \"$NAME\";
-        pwd; tar xzvf -"
-    - echo "Preview ${SERVER_URL_BASE}/${NAME}"
+    #- echo "The sync_merge_to_github job was triggered!"
+    - apt-get update && apt-get install -y git gh
+    - export SOURCE_BRANCH="${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME}"
+    - export GITHUB_REPO="f-hollow/developer-portal"
 
-post_preview_link:
-  stage: comment
-  image: badouralix/curl-jq
-  tags:
-    - deploy_docs
-    - shiny
-  rules:
-    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-  needs: ["deploy_preview_hugo"]
-  variables:
-    SERVER_URL_BASE: "$DOCS_PREVIEW_URL_BASE"
-    NAME: "${CI_COMMIT_REF_SLUG}"
-    MR_ID: "$CI_MERGE_REQUEST_IID"
-    PROJECT_ID: "$CI_MERGE_REQUEST_PROJECT_ID"
-  script:
+    # Configure Git
+    - git config --global user.email "developer.portal.bot@example.com"
+    - git config --global user.name "Developer-Portal-BOT"
+
+    # Clone the repository
+    - git clone "$CI_REPOSITORY_URL" repo
+    - cd repo
+    # Rebase the feature branch on main
+    - git checkout "$SOURCE_BRANCH"
+    - git fetch origin main
+    - git rebase main
+    # Add GitHub remote and push the rebased branch to GitHub
+    - git remote add github "https://oauth2:${GITHUB_ACCESS_TOKEN}@github.com/${GITHUB_REPO}.git"
+    # Consider using --force-with-lease here
+    - git push -u -f github "$SOURCE_BRANCH"
+
+    # Wait for GitHub to register the branch
+    - sleep 5
+
+    # Create a PR on GitHub
+    - export GITHUB_TOKEN="$GITHUB_ACCESS_TOKEN"
     - |
-      # Print MR_ID and PROJECT_ID for debugging
-      echo "MR_ID: ${MR_ID}"
-      echo "PROJECT_ID: ${PROJECT_ID}"
-      echo "$CI_SERVER_HOST"
-      echo "${CI_SERVER_PORT}"
-
-      GITLAB_API="https://${CI_SERVER_HOST}:${CI_SERVER_PORT}/api/v4/projects/${PROJECT_ID}/merge_requests/${MR_ID}/notes"
-      AUTH_HEADER="PRIVATE-TOKEN: ${GITLAB_BOT_API_TOKEN}"
-
-      # Get existing comments
-      API_RESPONSE=$(curl --silent --header "$AUTH_HEADER" "$GITLAB_API")
-      echo "API Response: $API_RESPONSE"  # Add this line for debugging
-
-      # Check if the response contains the expected structure
-      COMMENTS=$(echo "$API_RESPONSE" | jq -r '.[] | select(.body | contains("🎉 Preview for this MR")) | .id')
-
-      # Delete previous preview comments
-      if [ -n "$COMMENTS" ]; then
-        for COMMENT_ID in $COMMENTS; do
-          curl --silent --request DELETE --header "$AUTH_HEADER" "${GITLAB_API}/${COMMENT_ID}"
-        done
+      if gh pr list --repo "$GITHUB_REPO" --head "$SOURCE_BRANCH" | grep -q "$SOURCE_BRANCH"; then
+        echo "PR already exists. Skipping..."
+      else
+        gh pr create \
+          --repo "$GITHUB_REPO" \
+          --head "$SOURCE_BRANCH" \
+          --base main \
+          --title "Sync Merge: ${SOURCE_BRANCH}" \
+          --body "This PR syncs the GitLab branch ${SOURCE_BRANCH} to GitHub." \
+          --label "enhancement"
+        echo "PR created successfully with label 'GitLab-Sync-Merge'."
       fi
 
-      # Post new preview link
-      PREVIEW_LINK="${SERVER_URL_BASE}/${NAME}"
-      COMMENT_BODY="🎉 Preview for this MR: ${PREVIEW_LINK}"
-      curl --silent --request POST --header "$AUTH_HEADER" --header "Content-Type: application/json" \
-        --data "{\"body\": \"${COMMENT_BODY}\"}" "$GITLAB_API"
+    # - |
+    #     if gh pr create \
+    #       --repo "$GITHUB_REPO" \
+    #       --head "$SOURCE_BRANCH" \
+    #       --base main \
+    #       --title "Sync Merge: ${SOURCE_BRANCH}" \
+    #       --body "This PR syncs the GitLab branch ${SOURCE_BRANCH} to GitHub." \
+    #       --label "enhancement"
+    #     then
+    #       echo "PR created successfully with label 'GitLab-Sync-Merge'."
+    #     else
+    #       echo "PR already exists or another error occurred. Skipping..."
+    #     fi
+
+# build_hugo:
+#   stage: build
+#   image: "${CI_TEMPLATE_REGISTRY_HOST}/pages/hugo/hugo_extended:0.135.0"
+#   tags:
+#     - build_docs
+#   rules:
+#     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+#   variables:
+#     GIT_SUBMODULE_STRATEGY: recursive
+#     NAME: "${CI_COMMIT_REF_SLUG}"
+#   script:
+#     - hugo --gc --minify --environment staging --baseURL "${DOCS_PREVIEW_URL_BASE}/${NAME}"
+#     # use branch name like directory name for the URL path going forward
+#     - mv -v public "${NAME}"
+#     - tar -czf archive.tar.gz "${NAME}"
+#   artifacts:
+#     paths:
+#       - archive.tar.gz
+#     expire_in: 1 week
+
+# deploy_preview_hugo:
+#   stage: deploy
+#   image: espressif/scp
+#   tags:
+#     - deploy_docs
+#     - shiny
+#   rules:
+#     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+#   needs: ["build_hugo"]
+#   variables:
+#     SSH_KEY: "$DOCS_PREVIEW_PRIVATEKEY" # SSH_KEY used inside espressif/scp
+#     SERVER_PATH: "$DOCS_PREVIEW_PATH"
+#     SERVER_URL_BASE: "$DOCS_PREVIEW_URL_BASE"
+#     USER: "$DOCS_PREVIEW_SERVER_USER"
+#     SERVER: "$DOCS_PREVIEW_SERVER"
+#     NAME: "${CI_COMMIT_REF_SLUG}"
+#   script:
+#     # upload and extract the archive,
+#     # delete the old directory with the same name (if doesn't contain . or /)
+#     # so as not to accumulate garbage from the previous run
+#     - cat archive.tar.gz | ssh ${USER}@${SERVER}
+#         "cd ${SERVER_PATH};
+#         [[ \"$NAME\" != *.* && \"$NAME\" != */* ]] && [ -d \"$NAME\" ] && rm -rf \"$NAME\";
+#         pwd; tar xzvf -"
+#     - echo "Preview ${SERVER_URL_BASE}/${NAME}"
+
+# post_preview_link:
+#   stage: comment
+#   image: badouralix/curl-jq
+#   tags:
+#     - deploy_docs
+#     - shiny
+#   rules:
+#     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+#   needs: ["deploy_preview_hugo"]
+#   variables:
+#     SERVER_URL_BASE: "$DOCS_PREVIEW_URL_BASE"
+#     NAME: "${CI_COMMIT_REF_SLUG}"
+#     MR_ID: "$CI_MERGE_REQUEST_IID"
+#     PROJECT_ID: "$CI_MERGE_REQUEST_PROJECT_ID"
+#   script:
+#     - |
+#       # Print MR_ID and PROJECT_ID for debugging
+#       echo "MR_ID: ${MR_ID}"
+#       echo "PROJECT_ID: ${PROJECT_ID}"
+#       echo "$CI_SERVER_HOST"
+#       echo "${CI_SERVER_PORT}"
+
+#       GITLAB_API="https://${CI_SERVER_HOST}:${CI_SERVER_PORT}/api/v4/projects/${PROJECT_ID}/merge_requests/${MR_ID}/notes"
+#       AUTH_HEADER="PRIVATE-TOKEN: ${GITLAB_BOT_API_TOKEN}"
+
+#       # Get existing comments
+#       API_RESPONSE=$(curl --silent --header "$AUTH_HEADER" "$GITLAB_API")
+#       echo "API Response: $API_RESPONSE"  # Add this line for debugging
+
+#       # Check if the response contains the expected structure
+#       COMMENTS=$(echo "$API_RESPONSE" | jq -r '.[] | select(.body | contains("🎉 Preview for this MR")) | .id')
+
+#       # Delete previous preview comments
+#       if [ -n "$COMMENTS" ]; then
+#         for COMMENT_ID in $COMMENTS; do
+#           curl --silent --request DELETE --header "$AUTH_HEADER" "${GITLAB_API}/${COMMENT_ID}"
+#         done
+#       fi
+
+#       # Post new preview link
+#       PREVIEW_LINK="${SERVER_URL_BASE}/${NAME}"
+#       COMMENT_BODY="🎉 Preview for this MR: ${PREVIEW_LINK}"
+#       curl --silent --request POST --header "$AUTH_HEADER" --header "Content-Type: application/json" \
+#         --data "{\"body\": \"${COMMENT_BODY}\"}" "$GITLAB_API"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,9 @@
+.comment_template:
+  image: badouralix/curl-jq
+  tags:
+    - deploy_docs
+    - shiny
+
 .add_comment_script: &add_comment_script
   - |
     GITLAB_API="https://${CI_SERVER_HOST}:${CI_SERVER_PORT}/api/v4/projects/${PROJECT_ID}/merge_requests/${MR_ID}/notes"
@@ -25,6 +31,15 @@
       --data "{\"body\": \"$COMMENT_BODY\"}" \
       "$GITLAB_API"
 
+# Define the reusable rule sets
+.default-rules:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+
+.label-based-rules:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_LABELS =~ /GitHub-Sync-Merge/ && $CI_MERGE_REQUEST_LABELS !~ /GitHub-Edit/'
+
 stages:
   - build
   - deploy
@@ -38,7 +53,7 @@ build_hugo:
   tags:
     - build_docs
   rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    !reference [.default-rules, rules]
   variables:
     GIT_SUBMODULE_STRATEGY: recursive
     NAME: "${CI_COMMIT_REF_SLUG}"
@@ -59,7 +74,7 @@ deploy_preview_hugo:
     - deploy_docs
     - shiny
   rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    !reference [.default-rules, rules]
   needs: ["build_hugo"]
   variables:
     SSH_KEY: "$DOCS_PREVIEW_PRIVATEKEY" # SSH_KEY used inside espressif/scp
@@ -79,13 +94,10 @@ deploy_preview_hugo:
     - echo "Preview ${SERVER_URL_BASE}/${NAME}"
 
 post_preview_link:
+  extends: .comment_template
   stage: comment_preview
-  image: badouralix/curl-jq
-  tags:
-    - deploy_docs
-    - shiny
   rules:
-    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    !reference [.default-rules, rules]
   needs: ["deploy_preview_hugo"]
   variables:
     SERVER_URL_BASE: "$DOCS_PREVIEW_URL_BASE"
@@ -95,10 +107,9 @@ post_preview_link:
   script:
     - |
       # Create varialbes for adding a comment
-      COMMENT_IDENTIFIER="🎉 Preview for this MR"
-
-      PREVIEW_LINK="${SERVER_URL_BASE}/${NAME}"
-      COMMENT_BODY="🎉 Preview for this MR: ${PREVIEW_LINK}"
+      export COMMENT_IDENTIFIER="🎉 Preview for this MR"
+      export PREVIEW_LINK="${SERVER_URL_BASE}/${NAME}"
+      export COMMENT_BODY="🎉 Preview for this MR: ${PREVIEW_LINK}"
 
     - *add_comment_script
 
@@ -115,7 +126,7 @@ sync_merge_to_github:
     - deploy_docs
     - shiny
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_LABELS =~ /GitHub-Sync-Merge/ && $CI_MERGE_REQUEST_LABELS !~ /GitHub-Edit/'
+    !reference [.label-based-rules, rules]
   variables:
     GITHUB_REPO: "f-hollow/developer-portal"
   script:
@@ -193,13 +204,10 @@ sync_merge_to_github:
     expire_in: 1 hour
 
 sync_merge_comment:
+  extends: .comment_template
   stage: comment_github_pr
-  image: badouralix/curl-jq
-  tags:
-    - deploy_docs
-    - shiny
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_LABELS =~ /GitHub-Sync-Merge/ && $CI_MERGE_REQUEST_LABELS !~ /GitHub-Edit/'
+    !reference [.label-based-rules, rules]
   needs:
     - sync_merge_to_github
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-.add_comment: &add_comment
+.add_comment_script: &add_comment_script
   - |
     GITLAB_API="https://${CI_SERVER_HOST}:${CI_SERVER_PORT}/api/v4/projects/${PROJECT_ID}/merge_requests/${MR_ID}/notes"
     AUTH_HEADER="PRIVATE-TOKEN: ${GITLAB_BOT_API_TOKEN}"
@@ -100,7 +100,7 @@ post_preview_link:
       PREVIEW_LINK="${SERVER_URL_BASE}/${NAME}"
       COMMENT_BODY="🎉 Preview for this MR: ${PREVIEW_LINK}"
 
-    - *add_comment
+    - *add_comment_script
 
 # After testing:
 #- Replace f-hollow with espressif
@@ -110,24 +110,26 @@ post_preview_link:
 #- Replace enhancement with GitHub-Sync-Merge
 sync_merge_to_github:
   stage: sync_merge
-  image: ubuntu:latest
+  image: alpine:latest
   tags:
     - deploy_docs
     - shiny
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_LABELS =~ /GitHub-Sync-Merge/ && $CI_MERGE_REQUEST_LABELS !~ /GitHub-Edit/'
+  variables:
+    GITHUB_REPO: "f-hollow/developer-portal"
   script:
-    #- echo "The sync_merge_to_github job was triggered!"
-    - apt-get update && apt-get install -y git gh
+    - apk update # Update the package index
+    - apk add --no-cache git bash github-cli # Install github-cli
+
     - export SOURCE_BRANCH="${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME}"
-    - export GITHUB_REPO="f-hollow/developer-portal"
 
     # Configure Git
     - git config --global user.email "developer.portal.bot@example.com"
     - git config --global user.name "Developer-Portal-BOT"
 
     # Clone the repository
-    - git clone "$CI_REPOSITORY_URL" repo
+    - git clone "$CI_REPOSITORY_URL" repo || (echo "Error cloning repository" && exit 1)
     - cd repo
     # Rebase the feature branch on main
     - git checkout "$SOURCE_BRANCH"
@@ -219,4 +221,4 @@ sync_merge_comment:
       COMMENT_IDENTIFIER="🚀 GitHub PR"
       COMMENT_BODY="🚀 GitHub PR for sync-merging: [#$PR_NUMBER]($PR_URL).\\n\\n> [!NOTE]\\n> \\n> If you plan to commit changes to the GitHub PR directly bypassing GitLab, assign here the label \`GitHub-Edit\` to prevent accidentally overwriting the changes on GitHub by GitLab CI sync-merge."
 
-    - *add_comment
+    - *add_comment_script

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,21 +1,121 @@
-stages:
-  # - build
-  # - deploy
-  # - comment
-  - sync_merge
+.add_comment: &add_comment
+  - |
+    GITLAB_API="https://${CI_SERVER_HOST}:${CI_SERVER_PORT}/api/v4/projects/${PROJECT_ID}/merge_requests/${MR_ID}/notes"
+    AUTH_HEADER="PRIVATE-TOKEN: ${GITLAB_BOT_API_TOKEN}"
 
-# After testing:
-#- Replace f-hollow with espressif
-#- Replace enhancement with GitLab-Sync-Merge
-#- Figure out which GitHub token to use
-sync_merge_to_github:
-  stage: sync_merge
-  image: debian:latest
+    # Get existing comments
+    API_RESPONSE=$(curl --silent --header "$AUTH_HEADER" "$GITLAB_API")
+
+    # Check if the response contains the expected structure
+    COMMENTS=$(echo "$API_RESPONSE" | jq -r ".[] | select(.body | contains(\"$COMMENT_IDENTIFIER\")) | .id")
+
+    # Delete previous preview comments
+    if [ -n "$COMMENTS" ]; then
+      for COMMENT_ID in $COMMENTS; do
+        curl --silent --request DELETE \
+          --header "$AUTH_HEADER" \
+          "${GITLAB_API}/${COMMENT_ID}"
+      done
+    fi
+
+    # Post a new comment
+    curl --silent --request POST \
+      --header "$AUTH_HEADER" \
+      --header "Content-Type: application/json" \
+      --data "{\"body\": \"$COMMENT_BODY\"}" \
+      "$GITLAB_API"
+
+stages:
+  - build
+  - deploy
+  - comment_preview
+  - sync_merge
+  - comment_github_pr
+
+build_hugo:
+  stage: build
+  image: "${CI_TEMPLATE_REGISTRY_HOST}/pages/hugo/hugo_extended:0.135.0"
+  tags:
+    - build_docs
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  variables:
+    GIT_SUBMODULE_STRATEGY: recursive
+    NAME: "${CI_COMMIT_REF_SLUG}"
+  script:
+    - hugo --gc --minify --environment staging --baseURL "${DOCS_PREVIEW_URL_BASE}/${NAME}"
+    # use branch name like directory name for the URL path going forward
+    - mv -v public "${NAME}"
+    - tar -czf archive.tar.gz "${NAME}"
+  artifacts:
+    paths:
+      - archive.tar.gz
+    expire_in: 1 week
+
+deploy_preview_hugo:
+  stage: deploy
+  image: espressif/scp
   tags:
     - deploy_docs
     - shiny
   rules:
-    - if: '$CI_MERGE_REQUEST_LABELS =~ /GitHub-Sync-Merge/'
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  needs: ["build_hugo"]
+  variables:
+    SSH_KEY: "$DOCS_PREVIEW_PRIVATEKEY" # SSH_KEY used inside espressif/scp
+    SERVER_PATH: "$DOCS_PREVIEW_PATH"
+    SERVER_URL_BASE: "$DOCS_PREVIEW_URL_BASE"
+    USER: "$DOCS_PREVIEW_SERVER_USER"
+    SERVER: "$DOCS_PREVIEW_SERVER"
+    NAME: "${CI_COMMIT_REF_SLUG}"
+  script:
+    # upload and extract the archive,
+    # delete the old directory with the same name (if doesn't contain . or /)
+    # so as not to accumulate garbage from the previous run
+    - cat archive.tar.gz | ssh ${USER}@${SERVER}
+        "cd ${SERVER_PATH};
+        [[ \"$NAME\" != *.* && \"$NAME\" != */* ]] && [ -d \"$NAME\" ] && rm -rf \"$NAME\";
+        pwd; tar xzvf -"
+    - echo "Preview ${SERVER_URL_BASE}/${NAME}"
+
+post_preview_link:
+  stage: comment_preview
+  image: badouralix/curl-jq
+  tags:
+    - deploy_docs
+    - shiny
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  needs: ["deploy_preview_hugo"]
+  variables:
+    SERVER_URL_BASE: "$DOCS_PREVIEW_URL_BASE"
+    NAME: "${CI_COMMIT_REF_SLUG}"
+    MR_ID: "$CI_MERGE_REQUEST_IID"
+    PROJECT_ID: "$CI_MERGE_REQUEST_PROJECT_ID"
+  script:
+    - |
+      # Create varialbes for adding a comment
+      COMMENT_IDENTIFIER="🎉 Preview for this MR"
+
+      PREVIEW_LINK="${SERVER_URL_BASE}/${NAME}"
+      COMMENT_BODY="🎉 Preview for this MR: ${PREVIEW_LINK}"
+
+    - *add_comment
+
+# After testing:
+#- Replace f-hollow with espressif
+#  - Make sure that my PAT token works
+#  - Try creating a new PR and updating an existing one
+#  - Test how PR description appears
+#- Replace enhancement with GitHub-Sync-Merge
+sync_merge_to_github:
+  stage: sync_merge
+  image: ubuntu:latest
+  tags:
+    - deploy_docs
+    - shiny
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_LABELS =~ /GitHub-Sync-Merge/ && $CI_MERGE_REQUEST_LABELS !~ /GitHub-Edit/'
   script:
     #- echo "The sync_merge_to_github job was triggered!"
     - apt-get update && apt-get install -y git gh
@@ -44,120 +144,79 @@ sync_merge_to_github:
     # Create a PR on GitHub
     - export GITHUB_TOKEN="$GITHUB_ACCESS_TOKEN"
     - |
-      if gh pr list --repo "$GITHUB_REPO" --head "$SOURCE_BRANCH" | grep -q "$SOURCE_BRANCH"; then
-        echo "PR already exists. Skipping..."
+      PR_URL=$(gh pr list \
+              --repo "$GITHUB_REPO" \
+              --head "$SOURCE_BRANCH" \
+              --json url \
+              --jq '.[].url')
+
+      if [[ -n "$PR_URL" ]]; then
+        PR_NUMBER=$(gh pr view "$PR_URL" --json number -q '.number')
+        echo "PR already exists: #$PR_NUMBER"
+        echo "**GitHub PR:** $PR_URL"
       else
+        echo "No PR found. Creating a new one..."
         gh pr create \
           --repo "$GITHUB_REPO" \
           --head "$SOURCE_BRANCH" \
           --base main \
           --title "Sync Merge: ${SOURCE_BRANCH}" \
-          --body "This PR syncs the GitLab branch ${SOURCE_BRANCH} to GitHub." \
+          --body $'This PR syncs the GitLab branch `'"${SOURCE_BRANCH}"$'` to GitHub.\n\nThe changes have been reviewed internally.\n\n> [!NOTE]\n>If you plan to commit changes here directly bypassing GitLab, assign in GitLab MR the label `GitHub-Edit` to prevent accidentally overwriting these changes by GitLab CI sync-merge.' \
           --label "enhancement"
-        echo "PR created successfully with label 'GitLab-Sync-Merge'."
+
+        PR_URL=$(gh pr list \
+                --repo "$GITHUB_REPO" \
+                --head "$SOURCE_BRANCH" \
+                --json url \
+                --jq '.[].url')
+
+        if [[ -n "$PR_URL" ]]; then
+          PR_NUMBER=$(gh pr view "$PR_URL" --json number -q '.number')
+          echo "PR created successfully: #$PR_NUMBER"
+          echo "**GitHub PR:** $PR_URL"
+        else
+          echo "Failed to create PR."
+          exit 1
+        fi
       fi
 
-    # - |
-    #     if gh pr create \
-    #       --repo "$GITHUB_REPO" \
-    #       --head "$SOURCE_BRANCH" \
-    #       --base main \
-    #       --title "Sync Merge: ${SOURCE_BRANCH}" \
-    #       --body "This PR syncs the GitLab branch ${SOURCE_BRANCH} to GitHub." \
-    #       --label "enhancement"
-    #     then
-    #       echo "PR created successfully with label 'GitLab-Sync-Merge'."
-    #     else
-    #       echo "PR already exists or another error occurred. Skipping..."
-    #     fi
+    # Store PR_NUMBER and PR_URL as artifacts
+    - cd $CI_PROJECT_DIR
+    - echo "PR_NUMBER=$PR_NUMBER" > pr_info.txt
+    - echo "PR_URL=$PR_URL" >> pr_info.txt
 
-# build_hugo:
-#   stage: build
-#   image: "${CI_TEMPLATE_REGISTRY_HOST}/pages/hugo/hugo_extended:0.135.0"
-#   tags:
-#     - build_docs
-#   rules:
-#     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-#   variables:
-#     GIT_SUBMODULE_STRATEGY: recursive
-#     NAME: "${CI_COMMIT_REF_SLUG}"
-#   script:
-#     - hugo --gc --minify --environment staging --baseURL "${DOCS_PREVIEW_URL_BASE}/${NAME}"
-#     # use branch name like directory name for the URL path going forward
-#     - mv -v public "${NAME}"
-#     - tar -czf archive.tar.gz "${NAME}"
-#   artifacts:
-#     paths:
-#       - archive.tar.gz
-#     expire_in: 1 week
+  artifacts:
+    paths:
+      - pr_info.txt
+    expire_in: 1 hour
 
-# deploy_preview_hugo:
-#   stage: deploy
-#   image: espressif/scp
-#   tags:
-#     - deploy_docs
-#     - shiny
-#   rules:
-#     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-#   needs: ["build_hugo"]
-#   variables:
-#     SSH_KEY: "$DOCS_PREVIEW_PRIVATEKEY" # SSH_KEY used inside espressif/scp
-#     SERVER_PATH: "$DOCS_PREVIEW_PATH"
-#     SERVER_URL_BASE: "$DOCS_PREVIEW_URL_BASE"
-#     USER: "$DOCS_PREVIEW_SERVER_USER"
-#     SERVER: "$DOCS_PREVIEW_SERVER"
-#     NAME: "${CI_COMMIT_REF_SLUG}"
-#   script:
-#     # upload and extract the archive,
-#     # delete the old directory with the same name (if doesn't contain . or /)
-#     # so as not to accumulate garbage from the previous run
-#     - cat archive.tar.gz | ssh ${USER}@${SERVER}
-#         "cd ${SERVER_PATH};
-#         [[ \"$NAME\" != *.* && \"$NAME\" != */* ]] && [ -d \"$NAME\" ] && rm -rf \"$NAME\";
-#         pwd; tar xzvf -"
-#     - echo "Preview ${SERVER_URL_BASE}/${NAME}"
+sync_merge_comment:
+  stage: comment_github_pr
+  image: badouralix/curl-jq
+  tags:
+    - deploy_docs
+    - shiny
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_LABELS =~ /GitHub-Sync-Merge/ && $CI_MERGE_REQUEST_LABELS !~ /GitHub-Edit/'
+  needs:
+    - sync_merge_to_github
+  variables:
+    SERVER_URL_BASE: "$DOCS_PREVIEW_URL_BASE"
+    NAME: "${CI_COMMIT_REF_SLUG}"
+    MR_ID: "$CI_MERGE_REQUEST_IID"
+    PROJECT_ID: "$CI_MERGE_REQUEST_PROJECT_ID"
+  script:
+    - |
+      # Load PR_NUMBER and PR_URL from artifact file
+      if [ -f "pr_info.txt" ]; then
+        source pr_info.txt
+      else
+        echo "pr_info.txt not found!"
+        exit 1
+      fi
 
-# post_preview_link:
-#   stage: comment
-#   image: badouralix/curl-jq
-#   tags:
-#     - deploy_docs
-#     - shiny
-#   rules:
-#     - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
-#   needs: ["deploy_preview_hugo"]
-#   variables:
-#     SERVER_URL_BASE: "$DOCS_PREVIEW_URL_BASE"
-#     NAME: "${CI_COMMIT_REF_SLUG}"
-#     MR_ID: "$CI_MERGE_REQUEST_IID"
-#     PROJECT_ID: "$CI_MERGE_REQUEST_PROJECT_ID"
-#   script:
-#     - |
-#       # Print MR_ID and PROJECT_ID for debugging
-#       echo "MR_ID: ${MR_ID}"
-#       echo "PROJECT_ID: ${PROJECT_ID}"
-#       echo "$CI_SERVER_HOST"
-#       echo "${CI_SERVER_PORT}"
+      # Create varialbes for adding a comment
+      COMMENT_IDENTIFIER="🚀 GitHub PR"
+      COMMENT_BODY="🚀 GitHub PR for sync-merging: [#$PR_NUMBER]($PR_URL).\\n\\n> [!NOTE]\\n> \\n> If you plan to commit changes to the GitHub PR directly bypassing GitLab, assign here the label \`GitHub-Edit\` to prevent accidentally overwriting the changes on GitHub by GitLab CI sync-merge."
 
-#       GITLAB_API="https://${CI_SERVER_HOST}:${CI_SERVER_PORT}/api/v4/projects/${PROJECT_ID}/merge_requests/${MR_ID}/notes"
-#       AUTH_HEADER="PRIVATE-TOKEN: ${GITLAB_BOT_API_TOKEN}"
-
-#       # Get existing comments
-#       API_RESPONSE=$(curl --silent --header "$AUTH_HEADER" "$GITLAB_API")
-#       echo "API Response: $API_RESPONSE"  # Add this line for debugging
-
-#       # Check if the response contains the expected structure
-#       COMMENTS=$(echo "$API_RESPONSE" | jq -r '.[] | select(.body | contains("🎉 Preview for this MR")) | .id')
-
-#       # Delete previous preview comments
-#       if [ -n "$COMMENTS" ]; then
-#         for COMMENT_ID in $COMMENTS; do
-#           curl --silent --request DELETE --header "$AUTH_HEADER" "${GITLAB_API}/${COMMENT_ID}"
-#         done
-#       fi
-
-#       # Post new preview link
-#       PREVIEW_LINK="${SERVER_URL_BASE}/${NAME}"
-#       COMMENT_BODY="🎉 Preview for this MR: ${PREVIEW_LINK}"
-#       curl --silent --request POST --header "$AUTH_HEADER" --header "Content-Type: application/json" \
-#         --data "{\"body\": \"${COMMENT_BODY}\"}" "$GITLAB_API"
+    - *add_comment


### PR DESCRIPTION
This PR syncs the GitLab branch `ci/sync_merge_gitlab_to_github` to GitHub.

The changes have been reviewed internally.

> [!NOTE]
>If you plan to commit changes here directly bypassing GitLab, assign in GitLab MR the label `GitHub-Edit` to prevent accidentally overwriting these changes by GitLab CI sync-merge.